### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or with yarn
 In Node:
 
 ```js
-const Tablo = require('tablo-api');
+const {Tablo} = require('tablo-api');
 
 const Api = new Tablo();
 


### PR DESCRIPTION
Was not working for me before:

```
const Api = new Tablo();
            ^
TypeError: Tablo is not a constructor
```